### PR TITLE
fix import TabContent from es-modules

### DIFF
--- a/src/components/tabs/Tabs.js
+++ b/src/components/tabs/Tabs.js
@@ -1,7 +1,6 @@
 // @flow
 import React, { Component } from 'react'
-import RCTabs from 'rc-tabs'
-import TabContent from 'rc-tabs/lib/TabContent'
+import RCTabs, { TabContent } from 'rc-tabs'
 
 type Props = {
   children: React.Element<*>,


### PR DESCRIPTION
Фикс "Кривой импорт rc-tabs" https://github.com/kupibilet-frontend/ui/issues/63