### PR TITLE
Responsive fixes

### DIFF
--- a/src/blocks/tabs/Tab.js
+++ b/src/blocks/tabs/Tab.js
@@ -8,7 +8,6 @@ export default styled(Tab)`
 
   display: inline-block;
   padding: 0 10px;
-  margin-bottom: 42px;
   border-radius: 100px;
   line-height: 24px;
   user-select: none;

--- a/src/components/airport-input/styled.js
+++ b/src/components/airport-input/styled.js
@@ -26,7 +26,7 @@ export const Container = styled.div`
 
   height: 42px;
   width: 100%;
-  min-width: 180px;
+  min-width: 142px;
 
   display: flex;
   align-items: baseline;
@@ -185,6 +185,7 @@ export const Code = styled.div`
   position: relative;
   flex-grow: 0;
   flex-shrink: 0;
+  align-self: stretch;
 
   ${fontStyle}
   font-size: 14px;
@@ -196,7 +197,11 @@ export const Code = styled.div`
     ['right', 'both'].includes(neighboringInGroup) ? '10px' : '16px'
   )};
 
-  &:not(:empty)::before {
+  &:empty {
+    display: none;
+  }
+
+  &::before {
     content: '';
     display: block;
     position: absolute;

--- a/src/components/autocomplete/styled.js
+++ b/src/components/autocomplete/styled.js
@@ -2,11 +2,10 @@ import styled from 'styled-components'
 
 import { shadowSmall } from '../../utils/shadows'
 import { borderSmall } from '../../utils/borders'
+import mq from '../../utils/media-queries'
 
 export default styled.div`
-  .react-autosuggest__container {
-    position: relative;
-  }
+  .react-autosuggest__container {}
   .react-autosuggest__container--open {}
   .react-autosuggest__input {
     appearance: none;
@@ -29,10 +28,13 @@ export default styled.div`
   .react-autosuggest__suggestions-container--open {
     display: block;
     position: relative;
-    top: 3px;
+
+    ${mq.mobile`
+      position: static;
+    `}
   }
   .react-autosuggest__suggestions-list {
-    margin: 0;
+    margin: 3px 0 0;
     padding: 0;
     list-style-type: none;
     position: absolute;
@@ -43,7 +45,13 @@ export default styled.div`
     ${shadowSmall}
     ${borderSmall}
     overflow: hidden;
-    z-index: 2;
+    z-index: 10;
+
+    ${mq.mobile`
+      top: initial;
+      left: 0;
+      right: 0;
+    `}
   }
   .react-autosuggest__suggestion {
     cursor: pointer;

--- a/src/components/date-range/index.js
+++ b/src/components/date-range/index.js
@@ -219,7 +219,6 @@ DateRange.defaultProps = {
     dayPickerPadding: 9,
     monthPadding: 23,
     dayPickerWidth: 340,
-    inputWidth: 109,
   },
   renderInputText,
 }

--- a/src/components/date-range/styled/DateInput.js
+++ b/src/components/date-range/styled/DateInput.js
@@ -9,7 +9,7 @@ export default css`
 
     position: relative;
     display: inline-block;
-    width: ${({ dimensions }) => dimensions.inputWidth}px;
+    width: 50%;
     vertical-align: middle;
 
     .screen-reader-only {
@@ -79,13 +79,13 @@ export default css`
 
     // Input borders overlaying
     position: relative;
-    margin-right: -2px;
+    margin-right: 0;
     z-index: 1;
   }
 
   .DateInput ~ .DateInput .DateInput__display-text {
     border-radius: 0 100px 100px 0;
-    margin-right: 0;
+    margin-left: -2px;
     padding: 10px 16px 10px 10px;
   }
 

--- a/src/components/date-range/styled/DateRangePicker.js
+++ b/src/components/date-range/styled/DateRangePicker.js
@@ -1,16 +1,27 @@
 import { css } from 'styled-components'
+import mq from '../../../utils/media-queries'
 
 export default css`
   .DateRangePicker {
     position: relative;
-    display: inline-block;
+    display: block;
   }
 
   .DateRangePicker__picker {
     z-index: 10;
     background: ${({ theme }) => theme.color.background};
     position: absolute;
-    top: 45px;
+    margin-top: 3px;
+    top: 42px;
+
+    ${mq.mobile`
+      top: initial;
+      // Override style attr values added by DateRange controller
+      left: -20px !important;
+      right: -20px !important;
+      display: flex;
+      justify-content: center;
+    `}
   }
 
   .DateRangePicker__picker--direction-left {

--- a/src/components/date-range/styled/DateRangePickerInput.js
+++ b/src/components/date-range/styled/DateRangePickerInput.js
@@ -3,7 +3,7 @@ import { css } from 'styled-components'
 export default css`
   .DateRangePickerInput {
     background-color: ${({ theme }) => theme.color.background};
-    display: inline-block;
+    display: block;
   }
 
   // We don't use disabled state

--- a/src/components/date-range/styled/index.js
+++ b/src/components/date-range/styled/index.js
@@ -29,7 +29,7 @@ export const DateInputValue = styled.div`
   font-weight: 600;
 `
 export const DateInputDayOfWeek = styled.div`
-  color: ${({ theme }) => theme.color.text}
+  color: ${({ theme }) => theme.color.text};
   flex-shrink: 0;
 
   font-size: 14px;

--- a/src/components/dropdown/index.js
+++ b/src/components/dropdown/index.js
@@ -12,12 +12,17 @@ const DropdownWrapper = styled.div`
 
 const DropdownOverlay = styled.div`
   position: absolute;
-  top: calc(100% + 3px);
+  top: 100%;
+  margin-top: 3px;
   left: 0;
+  right: 0;
   padding: 18px 12px;
   background: ${({ theme }) => theme.color.background};
   ${shadowSmall}
   ${borderSmall}
+  z-index: 1;
+
+  margin-bottom: 18px;
 `
 
 type Props = {
@@ -33,10 +38,8 @@ class Dropdown extends React.PureComponent<{}, Props, void> {
     isOpen: false,
   }
 
-  onShow = (event: Event) => {
-    if (!this.props.isOpen) {
-      this.props.onToggle(event, true)
-    }
+  onToggle = (event: Event) => {
+    this.props.onToggle(event, !this.props.isOpen)
   }
 
   onHide = (event: Event) => {
@@ -53,7 +56,7 @@ class Dropdown extends React.PureComponent<{}, Props, void> {
     const { children, overlay, isOpen } = this.props
 
     const dropdownButton = React.cloneElement(children, {
-      onClick: this.onShow,
+      onClick: this.onToggle,
     })
 
     return (

--- a/test/__snapshots__/Storyshots.test.js.snap
+++ b/test/__snapshots__/Storyshots.test.js.snap
@@ -12,13 +12,13 @@ exports[`Storyshots Autocomplete Airport 1`] = `
     }
   >
     <div
-      className="sc-jhAzac jWxhGI"
+      className="sc-jhAzac iXQuyJ"
     >
       <div
         className="react-autosuggest__container"
       >
         <div
-          className="sc-jWBwVP cWgJos"
+          className="sc-jWBwVP fvSmgP"
         >
           <textarea
             aria-activedescendant={null}
@@ -53,7 +53,7 @@ exports[`Storyshots Autocomplete Airport 1`] = `
             
           </div>
           <div
-            className="sc-iRbamj gaPdQg"
+            className="sc-iRbamj fJefAy"
           >
             
           </div>
@@ -232,7 +232,7 @@ exports[`Storyshots Blocks Styled Tabs 1`] = `
     >
       <span
         aria-disabled={undefined}
-        className="sc-kjoXOD yKALr"
+        className="sc-kjoXOD ODnzO"
         onFocus={[Function]}
         role="tab"
         tabIndex="0"
@@ -241,7 +241,7 @@ exports[`Storyshots Blocks Styled Tabs 1`] = `
       </span>
       <span
         aria-disabled={undefined}
-        className="sc-kjoXOD cwzVks"
+        className="sc-kjoXOD eqmeva"
         onFocus={[Function]}
         role="tab"
         tabIndex="0"
@@ -250,7 +250,7 @@ exports[`Storyshots Blocks Styled Tabs 1`] = `
       </span>
       <span
         aria-disabled={undefined}
-        className="sc-kjoXOD yKALr"
+        className="sc-kjoXOD ODnzO"
         onFocus={[Function]}
         role="tab"
         tabIndex="0"
@@ -709,7 +709,7 @@ exports[`Storyshots ControlsGroup Different controls group 1`] = `
       </span>
     </button>
     <div
-      className="sc-jWBwVP Zabrz"
+      className="sc-jWBwVP exjCKk"
     >
       <textarea
         autoCapitalize="sentences"
@@ -735,7 +735,7 @@ exports[`Storyshots ControlsGroup Different controls group 1`] = `
         
       </div>
       <div
-        className="sc-iRbamj euucqi"
+        className="sc-iRbamj llOgDF"
       >
         SVO
       </div>
@@ -764,7 +764,7 @@ exports[`Storyshots ControlsGroup Inputs group 1`] = `
     className="sc-chPdSV jlvujm"
   >
     <div
-      className="sc-jWBwVP hbhadg"
+      className="sc-jWBwVP hyAZDv"
     >
       <textarea
         autoCapitalize="sentences"
@@ -790,7 +790,7 @@ exports[`Storyshots ControlsGroup Inputs group 1`] = `
         
       </div>
       <div
-        className="sc-iRbamj euucqi"
+        className="sc-iRbamj llOgDF"
       >
         SVO
       </div>
@@ -810,7 +810,7 @@ exports[`Storyshots ControlsGroup Inputs group 1`] = `
       </svg>
     </div>
     <div
-      className="sc-jWBwVP iCGffF"
+      className="sc-jWBwVP bSkTbm"
     >
       <textarea
         autoCapitalize="sentences"
@@ -836,7 +836,7 @@ exports[`Storyshots ControlsGroup Inputs group 1`] = `
         
       </div>
       <div
-        className="sc-iRbamj gaPdQg"
+        className="sc-iRbamj fJefAy"
       >
         
       </div>
@@ -850,7 +850,7 @@ exports[`Storyshots DateRange DateRange 1`] = `
   className="sc-bdVaJa jBbfIF"
 >
   <div
-    className="sc-kEYyzF hpQkTk"
+    className="sc-kEYyzF dOrIrl"
   >
     <div
       className="DateInput--startDate--placeholder DateInput--endDate--placeholder"


### PR DESCRIPTION
- DateRange input: made fluid and `dimensions.inputWidth` was deprecated
- DateRange calendar and Autocomplete: now takes all of screen width on mobile
- Dropdown: takes full width of parent and can be toggled by clicking on its child
- AirportInput: fixed minWidth for mobile and empty IATA code overlaying
- TabBar: removed unnecessary margin

Должен быть опубликован как ui@2.2.0