### PR TITLE
fix for fluid layout

### DIFF
--- a/src/components/fluid-layout/index.js
+++ b/src/components/fluid-layout/index.js
@@ -37,7 +37,7 @@ const Aside = styled.div`
     margin-left: 0;
   }
 
-  ${({ top }) => top && 'order: 0;'}
+  ${({ beforeSection }) => beforeSection && 'order: 0;'}
 `
 Aside.displayName = 'Aside'
 

--- a/src/components/fluid-layout/index.js
+++ b/src/components/fluid-layout/index.js
@@ -1,52 +1,43 @@
 import styled from 'styled-components'
 
 const FluidContainer = styled.div`
-  margin: 0 18px;
+  width: 1176px;
+  margin: 0 auto;
   display: flex;
-  flex-direction: column;
-  align-items: stretch;
+  justify-content: space-between;
+  align-items: flex-start;
 
-  @media(min-width: 1000px) {
+  @media(max-width: 999px) {
     margin: 0;
-    padding: 0 18px;
-    justify-content: center;
-    align-items: flex-start;
-  }
-
-  @media(min-width: 1200px) {
-    width: 1164px;
-    margin: 0 auto;
+    width: auto;
+    flex-direction: column;
   }
 `
 FluidContainer.displayName = 'FluidContainer'
 
 const FluidSection = styled.div`
   flex-grow: 1;
+  max-width: 870px;
 
-  @media(min-width: 1000px) {
-    order: 1;
-  }
-
-  @media(min-width: 1200px) {
-    max-width: 870px;
+  @media(max-width: 999px) {
+    max-width: none;
+    width: 100%;
   }
 `
 FluidSection.displayName = 'FluidSection'
 
 const Aside = styled.div`
-  width: 100%;
+  width: 252px;
   flex-grow: 0;
   flex-shrink: 0;
+  margin-left: 42px;
 
-  @media(min-width: 1000px) {
-    order: 2;
-    width: 252px;
-    margin-left: 18px;
+  @media(max-width: 999px) {
+    width: auto;
+    margin-left: 0;
   }
 
-  @media(min-width: 1200px) {
-    margin-left: 42px;
-  }
+  ${({ top }) => top && 'order: 0;' }
 `
 Aside.displayName = 'Aside'
 

--- a/src/components/fluid-layout/index.js
+++ b/src/components/fluid-layout/index.js
@@ -37,7 +37,7 @@ const Aside = styled.div`
     margin-left: 0;
   }
 
-  ${({ top }) => top && 'order: 0;' }
+  ${({ top }) => top && 'order: 0;'}
 `
 Aside.displayName = 'Aside'
 

--- a/src/components/fluid-layout/index.js
+++ b/src/components/fluid-layout/index.js
@@ -7,7 +7,8 @@ const FluidContainer = styled.div`
   align-items: stretch;
 
   @media(min-width: 1000px) {
-    flex-direction: row-reverse;
+    margin: 0;
+    padding: 0 18px;
     justify-content: center;
     align-items: flex-start;
   }
@@ -22,6 +23,10 @@ FluidContainer.displayName = 'FluidContainer'
 const FluidSection = styled.div`
   flex-grow: 1;
 
+  @media(min-width: 1000px) {
+    order: 1;
+  }
+
   @media(min-width: 1200px) {
     max-width: 870px;
   }
@@ -34,6 +39,7 @@ const Aside = styled.div`
   flex-shrink: 0;
 
   @media(min-width: 1000px) {
+    order: 2;
     width: 252px;
     margin-left: 18px;
   }

--- a/src/components/fluid-layout/stories.js
+++ b/src/components/fluid-layout/stories.js
@@ -51,7 +51,6 @@ storiesOf('Fluid layout', module)
     ),
   )
   .addWithInfo(
-    'Two columns',
     'Aside on top with beforeSection prop',
     () => (
       <FluidContainer>

--- a/src/components/fluid-layout/stories.js
+++ b/src/components/fluid-layout/stories.js
@@ -39,15 +39,28 @@ storiesOf('Fluid layout', module)
   ))
   .addWithInfo(
     'Two columns',
-    '<Aside> всегда должен быть первым дочерним блоком <FluidContainer>',
     () => (
       <FluidContainer>
-        <Aside>
-          <AsideContent />
-        </Aside>
         <FluidSection>
           <MainContent />
         </FluidSection>
+        <Aside>
+          <AsideContent />
+        </Aside>
+      </FluidContainer>
+    ),
+  )
+  .addWithInfo(
+    'Two columns',
+    'Aside on top with beforeSection prop',
+    () => (
+      <FluidContainer>
+        <FluidSection>
+          <MainContent />
+        </FluidSection>
+        <Aside beforeSection>
+          <AsideContent />
+        </Aside>
       </FluidContainer>
     ),
   )

--- a/test/__snapshots__/Storyshots.test.js.snap
+++ b/test/__snapshots__/Storyshots.test.js.snap
@@ -959,6 +959,59 @@ exports[`Storyshots Dropdown Defalut 1`] = `
 </div>
 `;
 
+exports[`Storyshots Fluid layout Aside on top with beforeSection prop 1`] = `
+<div
+  className="sc-bdVaJa jBbfIF"
+>
+  <div
+    style={
+      Object {
+        "width": "100vw",
+      }
+    }
+  >
+    <div
+      className="sc-kpOJdX exgQcK"
+    >
+      <div
+        className="sc-dxgOiQ kqIddl"
+      >
+        <div
+          style={
+            Object {
+              "alignItems": "center",
+              "background": "rgba(35, 194, 86, .4)",
+              "display": "flex",
+              "height": 140,
+              "justifyContent": "center",
+            }
+          }
+        >
+          Main content
+        </div>
+      </div>
+      <div
+        className="sc-ckVGcZ KNbIy"
+      >
+        <div
+          style={
+            Object {
+              "alignItems": "center",
+              "background": "rgba(230, 73, 38, .4)",
+              "display": "flex",
+              "height": 140,
+              "justifyContent": "center",
+            }
+          }
+        >
+          Sidebar
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storyshots Fluid layout Single column 1`] = `
 <div
   className="sc-bdVaJa jBbfIF"
@@ -1006,23 +1059,6 @@ exports[`Storyshots Fluid layout Two columns 1`] = `
       className="sc-kpOJdX exgQcK"
     >
       <div
-        className="sc-ckVGcZ dlJzzS"
-      >
-        <div
-          style={
-            Object {
-              "alignItems": "center",
-              "background": "rgba(230, 73, 38, .4)",
-              "display": "flex",
-              "height": 140,
-              "justifyContent": "center",
-            }
-          }
-        >
-          Sidebar
-        </div>
-      </div>
-      <div
         className="sc-dxgOiQ kqIddl"
       >
         <div
@@ -1037,6 +1073,23 @@ exports[`Storyshots Fluid layout Two columns 1`] = `
           }
         >
           Main content
+        </div>
+      </div>
+      <div
+        className="sc-ckVGcZ dlJzzS"
+      >
+        <div
+          style={
+            Object {
+              "alignItems": "center",
+              "background": "rgba(230, 73, 38, .4)",
+              "display": "flex",
+              "height": 140,
+              "justifyContent": "center",
+            }
+          }
+        >
+          Sidebar
         </div>
       </div>
     </div>

--- a/test/__snapshots__/Storyshots.test.js.snap
+++ b/test/__snapshots__/Storyshots.test.js.snap
@@ -1003,10 +1003,10 @@ exports[`Storyshots Fluid layout Two columns 1`] = `
     }
   >
     <div
-      className="sc-kpOJdX dBRKwj"
+      className="sc-kpOJdX exgQcK"
     >
       <div
-        className="sc-ckVGcZ grYFsz"
+        className="sc-ckVGcZ dlJzzS"
       >
         <div
           style={
@@ -1023,7 +1023,7 @@ exports[`Storyshots Fluid layout Two columns 1`] = `
         </div>
       </div>
       <div
-        className="sc-dxgOiQ jZppib"
+        className="sc-dxgOiQ kqIddl"
       >
         <div
           style={

--- a/test/__snapshots__/Storyshots.test.js.snap
+++ b/test/__snapshots__/Storyshots.test.js.snap
@@ -1003,10 +1003,10 @@ exports[`Storyshots Fluid layout Two columns 1`] = `
     }
   >
     <div
-      className="sc-kpOJdX kNHDpU"
+      className="sc-kpOJdX dBRKwj"
     >
       <div
-        className="sc-ckVGcZ hAxPOz"
+        className="sc-ckVGcZ grYFsz"
       >
         <div
           style={
@@ -1023,7 +1023,7 @@ exports[`Storyshots Fluid layout Two columns 1`] = `
         </div>
       </div>
       <div
-        className="sc-dxgOiQ cDnpWx"
+        className="sc-dxgOiQ jZppib"
       >
         <div
           style={


### PR DESCRIPTION
1) основными стилями сделали десктопными, а брейкпоинты сделали для мобильных устройств
2) пока убрали все правила для размеров между 1000 и 1200px
3) переделали Aside: с row-reverse на order, добавили prop "beforeSection"