### PR TITLE
Don’t use css(…args) inside @media

### DIFF
--- a/src/utils/media-queries.js
+++ b/src/utils/media-queries.js
@@ -34,31 +34,31 @@ export const withMedia = (Component) => (
 )
 
 const media = {
-  mobile: (...args) => css`
+  mobile: (styles) => css`
     .responsive &, .responsive-booking & {
       @media ${queries.isMobile} {
-        ${css(...args)}
+        ${styles}
       }
     }
   `,
-  tablet: (...args) => css`
+  tablet: (styles) => css`
     .responsive &, .responsive-booking & {
       @media ${queries.isTablet} {
-        ${css(...args)}
+        ${styles}
       }
     }
   `,
-  handheld: (...args) => css`
+  handheld: (styles) => css`
     .responsive &, .responsive-booking & {
       @media ${queries.isHandheld} {
-        ${css(...args)}
+        ${styles}
       }
     }
   `,
-  desktop: (...args) => css`
+  desktop: (styles) => css`
     .responsive &, .responsive-booking & {
       @media ${queries.isDesktop} {
-        ${css(...args)}
+        ${styles}
       }
     }
   `,


### PR DESCRIPTION
styled-component v2.0.1
babel-plugin-styled-components v.1.1.7 with `ssr: true`

Before:
```js
const queries = {
  isHandheld: 'screen and (max-width: 999px)',
}

const handheld = (...args) => css`
    .responsive &, .responsive-booking & {
      @media ${queries.isHandheld} {
        ${css(...args)}
      }
    }
  `,

const SingleFluidSection = styled.div`
  margin: 0 auto;
  max-width: 966px;

  ${handheld`
    margin: 0 18px;
  `}
`
```
```css
  /* sc-component-id: sc-cSHVUG */

  .haJBQO {
    margin: 0 auto;
    max-width: 966px;
  }
  @media screen and (max-width: 999px) {
    .responsive .haJBQO,
    .responsive-booking .haJBQO {
      margin: 0 18px;
    }
  }

  .fhMHlW {
    margin: 0 18px;
    max-width: 966px;
  }
  @media (min-width: 1002px) {
    .fhMHlW {
      margin: 0 auto;
    }
  }
```

After:
```js
const queries = {
  isHandheld: 'screen and (max-width: 999px)',
}

const handheld = (styles) => css`
    .responsive &, .responsive-booking & {
      @media ${queries.isHandheld} {
        ${styled}
      }
    }
  `,

const SingleFluidSection = styled.div`
  margin: 0 auto;
  max-width: 966px;

  ${handheld`
    margin: 0 18px;
  `}
`
```

```css
  /* sc-component-id: sc-cSHVUG */

  .haJBQO {
    margin: 0 auto;
    max-width: 966px;
  }
  @media screen and (max-width: 999px) {
    .responsive .haJBQO,
    .responsive-booking .haJBQO {
      margin: 0 18px;
    }
  }
```