### PR TITLE
Bugfix/collapse overflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kupibilet/ui",
-  "version": "3.3.5-3",
+  "version": "3.3.5-4",
   "description": "UI kit for kupibilet web app",
   "scripts": {
     "pretest": "yarn lint:js && yarn lint:css",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kupibilet/ui",
-  "version": "3.3.4",
+  "version": "3.3.5-0",
   "description": "UI kit for kupibilet web app",
   "scripts": {
     "pretest": "yarn lint:js && yarn lint:css",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kupibilet/ui",
-  "version": "3.3.5-0",
+  "version": "3.3.5-1",
   "description": "UI kit for kupibilet web app",
   "scripts": {
     "pretest": "yarn lint:js && yarn lint:css",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kupibilet/ui",
-  "version": "3.3.5-1",
+  "version": "3.3.5-2",
   "description": "UI kit for kupibilet web app",
   "scripts": {
     "pretest": "yarn lint:js && yarn lint:css",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kupibilet/ui",
-  "version": "3.3.5-2",
+  "version": "3.3.5-3",
   "description": "UI kit for kupibilet web app",
   "scripts": {
     "pretest": "yarn lint:js && yarn lint:css",

--- a/src/components/Collapse/Panel.js
+++ b/src/components/Collapse/Panel.js
@@ -7,8 +7,12 @@ import styled from 'styled-components'
 import { switchTransition, time } from 'utils/transitions'
 
 const PanelStyled = styled(RcCollapse.Panel)`
-  overflow: ${({ isActive }) => (isActive ? 'visible' : 'hidden')};
-  animation: overflowDelay ${time}s forwards;
+  overflow: hidden;
+
+  &.rc-collapse-item-active {
+    overflow: visible;
+    animation: ${time * 4}s overflowDelay;
+  }
 
   .rc-collapse-content {
     ${switchTransition}
@@ -19,7 +23,7 @@ const PanelStyled = styled(RcCollapse.Panel)`
   }
 
   @keyframes overflowDelay {
-    100% { overflow: ${({ isActive }) => (isActive ? 'visible' : 'hidden')} };
+    from { overflow: hidden; }
   }
 `
 

--- a/src/components/Collapse/Panel.js
+++ b/src/components/Collapse/Panel.js
@@ -4,14 +4,11 @@ import React from 'react'
 import RcCollapse from 'rc-collapse'
 import styled from 'styled-components'
 
-import { switchTransition, time } from 'utils/transitions'
+import { switchTransition } from 'utils/transitions'
 
 const PanelStyled = styled(RcCollapse.Panel)`
-  overflow: hidden;
-
-  &.rc-collapse-item-active {
-    overflow: visible;
-    animation: ${time * 4}s overflowDelay;
+  .rc-collapse-anim {
+    overflow: hidden;
   }
 
   .rc-collapse-content {
@@ -20,10 +17,6 @@ const PanelStyled = styled(RcCollapse.Panel)`
 
   .rc-collapse-content.rc-collapse-content-inactive {
     display: none;
-  }
-
-  @keyframes overflowDelay {
-    from { overflow: hidden; }
   }
 `
 

--- a/src/components/Collapse/Panel.js
+++ b/src/components/Collapse/Panel.js
@@ -4,10 +4,11 @@ import React from 'react'
 import RcCollapse from 'rc-collapse'
 import styled from 'styled-components'
 
-import { switchTransition } from 'utils/transitions'
+import { switchTransition, time } from 'utils/transitions'
 
 const PanelStyled = styled(RcCollapse.Panel)`
-  overflow: hidden;
+  overflow: ${({ isActive }) => (isActive ? 'visible' : 'hidden')};
+  animation: overflowDelay ${time}s forwards;
 
   .rc-collapse-content {
     ${switchTransition}
@@ -15,6 +16,10 @@ const PanelStyled = styled(RcCollapse.Panel)`
 
   .rc-collapse-content.rc-collapse-content-inactive {
     display: none;
+  }
+
+  @keyframes overflowDelay {
+    100% { overflow: ${({ isActive }) => (isActive ? 'visible' : 'hidden')} };
   }
 `
 

--- a/test/__snapshots__/Storyshots.test.js.snap
+++ b/test/__snapshots__/Storyshots.test.js.snap
@@ -47,8 +47,12 @@ exports[`Storyshots Blocks FilterSection 1`] = `
 
 .c9 {
   overflow: hidden;
-  -webkit-animation: overflowDelay 0.15s forwards;
-  animation: overflowDelay 0.15s forwards;
+}
+
+.c9.rc-collapse-item-active {
+  overflow: visible;
+  -webkit-animation: 0.6s overflowDelay;
+  animation: 0.6s overflowDelay;
 }
 
 .c9 .rc-collapse-content {
@@ -594,8 +598,12 @@ exports[`Storyshots Complex controls/Collapse Accordion 1`] = `
 
 .c1 {
   overflow: hidden;
-  -webkit-animation: overflowDelay 0.15s forwards;
-  animation: overflowDelay 0.15s forwards;
+}
+
+.c1.rc-collapse-item-active {
+  overflow: visible;
+  -webkit-animation: 0.6s overflowDelay;
+  animation: 0.6s overflowDelay;
 }
 
 .c1 .rc-collapse-content {
@@ -683,8 +691,12 @@ exports[`Storyshots Complex controls/Collapse Default 1`] = `
 
 .c1 {
   overflow: hidden;
-  -webkit-animation: overflowDelay 0.15s forwards;
-  animation: overflowDelay 0.15s forwards;
+}
+
+.c1.rc-collapse-item-active {
+  overflow: visible;
+  -webkit-animation: 0.6s overflowDelay;
+  animation: 0.6s overflowDelay;
 }
 
 .c1 .rc-collapse-content {
@@ -770,25 +782,14 @@ exports[`Storyshots Complex controls/Collapse Default active panel 1`] = `
   box-sizing: border-box;
 }
 
-.c2 {
-  overflow: hidden;
-  -webkit-animation: overflowDelay 0.15s forwards;
-  animation: overflowDelay 0.15s forwards;
-}
-
-.c2 .rc-collapse-content {
-  -webkit-transition: 0.15s ease-out;
-  transition: 0.15s ease-out;
-}
-
-.c2 .rc-collapse-content.rc-collapse-content-inactive {
-  display: none;
-}
-
 .c1 {
+  overflow: hidden;
+}
+
+.c1.rc-collapse-item-active {
   overflow: visible;
-  -webkit-animation: overflowDelay 0.15s forwards;
-  animation: overflowDelay 0.15s forwards;
+  -webkit-animation: 0.6s overflowDelay;
+  animation: 0.6s overflowDelay;
 }
 
 .c1 .rc-collapse-content {
@@ -843,7 +844,7 @@ exports[`Storyshots Complex controls/Collapse Default active panel 1`] = `
         </div>
       </div>
       <div
-        className="rc-collapse-item c2"
+        className="rc-collapse-item c1"
         id={undefined}
         style={undefined}
       >
@@ -857,7 +858,7 @@ exports[`Storyshots Complex controls/Collapse Default active panel 1`] = `
         </div>
       </div>
       <div
-        className="rc-collapse-item c2"
+        className="rc-collapse-item c1"
         id={undefined}
         style={undefined}
       >

--- a/test/__snapshots__/Storyshots.test.js.snap
+++ b/test/__snapshots__/Storyshots.test.js.snap
@@ -47,6 +47,8 @@ exports[`Storyshots Blocks FilterSection 1`] = `
 
 .c9 {
   overflow: hidden;
+  -webkit-animation: overflowDelay 0.15s forwards;
+  animation: overflowDelay 0.15s forwards;
 }
 
 .c9 .rc-collapse-content {
@@ -592,6 +594,8 @@ exports[`Storyshots Complex controls/Collapse Accordion 1`] = `
 
 .c1 {
   overflow: hidden;
+  -webkit-animation: overflowDelay 0.15s forwards;
+  animation: overflowDelay 0.15s forwards;
 }
 
 .c1 .rc-collapse-content {
@@ -679,6 +683,8 @@ exports[`Storyshots Complex controls/Collapse Default 1`] = `
 
 .c1 {
   overflow: hidden;
+  -webkit-animation: overflowDelay 0.15s forwards;
+  animation: overflowDelay 0.15s forwards;
 }
 
 .c1 .rc-collapse-content {
@@ -764,8 +770,25 @@ exports[`Storyshots Complex controls/Collapse Default active panel 1`] = `
   box-sizing: border-box;
 }
 
-.c1 {
+.c2 {
   overflow: hidden;
+  -webkit-animation: overflowDelay 0.15s forwards;
+  animation: overflowDelay 0.15s forwards;
+}
+
+.c2 .rc-collapse-content {
+  -webkit-transition: 0.15s ease-out;
+  transition: 0.15s ease-out;
+}
+
+.c2 .rc-collapse-content.rc-collapse-content-inactive {
+  display: none;
+}
+
+.c1 {
+  overflow: visible;
+  -webkit-animation: overflowDelay 0.15s forwards;
+  animation: overflowDelay 0.15s forwards;
 }
 
 .c1 .rc-collapse-content {
@@ -820,7 +843,7 @@ exports[`Storyshots Complex controls/Collapse Default active panel 1`] = `
         </div>
       </div>
       <div
-        className="rc-collapse-item c1"
+        className="rc-collapse-item c2"
         id={undefined}
         style={undefined}
       >
@@ -834,7 +857,7 @@ exports[`Storyshots Complex controls/Collapse Default active panel 1`] = `
         </div>
       </div>
       <div
-        className="rc-collapse-item c1"
+        className="rc-collapse-item c2"
         id={undefined}
         style={undefined}
       >

--- a/test/__snapshots__/Storyshots.test.js.snap
+++ b/test/__snapshots__/Storyshots.test.js.snap
@@ -45,14 +45,8 @@ exports[`Storyshots Blocks FilterSection 1`] = `
   box-sizing: border-box;
 }
 
-.c9 {
+.c9 .rc-collapse-anim {
   overflow: hidden;
-}
-
-.c9.rc-collapse-item-active {
-  overflow: visible;
-  -webkit-animation: 0.6s overflowDelay;
-  animation: 0.6s overflowDelay;
 }
 
 .c9 .rc-collapse-content {
@@ -596,14 +590,8 @@ exports[`Storyshots Complex controls/Collapse Accordion 1`] = `
   box-sizing: border-box;
 }
 
-.c1 {
+.c1 .rc-collapse-anim {
   overflow: hidden;
-}
-
-.c1.rc-collapse-item-active {
-  overflow: visible;
-  -webkit-animation: 0.6s overflowDelay;
-  animation: 0.6s overflowDelay;
 }
 
 .c1 .rc-collapse-content {
@@ -689,14 +677,8 @@ exports[`Storyshots Complex controls/Collapse Default 1`] = `
   box-sizing: border-box;
 }
 
-.c1 {
+.c1 .rc-collapse-anim {
   overflow: hidden;
-}
-
-.c1.rc-collapse-item-active {
-  overflow: visible;
-  -webkit-animation: 0.6s overflowDelay;
-  animation: 0.6s overflowDelay;
 }
 
 .c1 .rc-collapse-content {
@@ -782,14 +764,8 @@ exports[`Storyshots Complex controls/Collapse Default active panel 1`] = `
   box-sizing: border-box;
 }
 
-.c1 {
+.c1 .rc-collapse-anim {
   overflow: hidden;
-}
-
-.c1.rc-collapse-item-active {
-  overflow: visible;
-  -webkit-animation: 0.6s overflowDelay;
-  animation: 0.6s overflowDelay;
 }
 
 .c1 .rc-collapse-content {


### PR DESCRIPTION
В анимационных целях в панельке используется `overflow: hidden`, но в контенте панельки может быть много всего интересного и overflow: hidden портит нам жизнь. 
Поэтому решил я убирать оверфлоу у раскрытых панелек по завершению анимации.
А сделать ето чтобы, нашёл я хак: https://stackoverflow.com/questions/27904886/can-i-apply-a-css-transition-to-the-overflow-property
Нашёл и беззастенчиво заюзал.
Но вопросы ето дело вызывать может определенные, поетому готов ваши просьбы и предложения выслушать, собственно говоря.