### PR TITLE
Fixed props for RFInput

### DIFF
--- a/src/components/Input/index.js
+++ b/src/components/Input/index.js
@@ -211,18 +211,15 @@ class InputControl extends React.PureComponent<void, Props, State> {
 
 type RFProps = FieldProps
 
-const RFInput = (props : RFProps) => {
-  const { input, meta } = props
-  return (
-    <InputControl
-      {...input}
-      {...meta}
-      {...props}
-      error={meta.touched && meta.error}
-      success={meta.touched && meta.valid}
-    />
-  )
-}
+const RFInput = ({ input, meta, ...props }: RFProps) => (
+  <InputControl
+    {...input}
+    {...meta}
+    {...props}
+    error={meta.touched && meta.error}
+    success={meta.touched && meta.valid}
+  />
+)
 
 export {
   InputControl as Input,


### PR DESCRIPTION
Если прокидывать `props`, на инпут дополнительно попадают `input` и `meta` пропсы, которые уже переданы в `{...input} и {...meta}`
Получается у нас по 2 лишних объекта на каждый инпут. Не хорошо.