### PR TITLE
change border radius for buttons

### DIFF
--- a/src/components/Button/__snapshots__/stories.storyshot
+++ b/src/components/Button/__snapshots__/stories.storyshot
@@ -27,7 +27,7 @@ exports[`Storyshots COMPONENTS|Controls/Buttons Button as <a href="" /> 1`] = `
   -webkit-transform: translateZ(0);
   -ms-transform: translateZ(0);
   transform: translateZ(0);
-  border-radius: 15px;
+  border-radius: 9px;
   padding: 6.0px;
   padding-right: 15px;
   padding-left: 15px;
@@ -108,7 +108,7 @@ exports[`Storyshots COMPONENTS|Controls/Buttons Default 1`] = `
   -webkit-transform: translateZ(0);
   -ms-transform: translateZ(0);
   transform: translateZ(0);
-  border-radius: 15px;
+  border-radius: 9px;
   padding: 6.0px;
   padding-right: 15px;
   padding-left: 15px;
@@ -206,7 +206,7 @@ exports[`Storyshots COMPONENTS|Controls/Buttons Icon-only button (custom icon) 1
   -webkit-transform: translateZ(0);
   -ms-transform: translateZ(0);
   transform: translateZ(0);
-  border-radius: 21px;
+  border-radius: 9px;
   padding: 11.0px;
   -webkit-transition: 0.15s ease-out;
   transition: 0.15s ease-out;
@@ -328,7 +328,7 @@ exports[`Storyshots COMPONENTS|Controls/Buttons Icon-only button 1`] = `
   -webkit-transform: translateZ(0);
   -ms-transform: translateZ(0);
   transform: translateZ(0);
-  border-radius: 21px;
+  border-radius: 9px;
   padding: 11.0px;
   -webkit-transition: 0.15s ease-out;
   transition: 0.15s ease-out;
@@ -452,7 +452,7 @@ exports[`Storyshots COMPONENTS|Controls/Buttons Loading button 1`] = `
   -webkit-transform: translateZ(0);
   -ms-transform: translateZ(0);
   transform: translateZ(0);
-  border-radius: 21px;
+  border-radius: 9px;
   padding: 11.0px;
   -webkit-transition: 0.15s ease-out;
   transition: 0.15s ease-out;
@@ -574,7 +574,7 @@ exports[`Storyshots COMPONENTS|Controls/Buttons With custom icons 1`] = `
   -webkit-transform: translateZ(0);
   -ms-transform: translateZ(0);
   transform: translateZ(0);
-  border-radius: 15px;
+  border-radius: 9px;
   padding: 6.0px;
   padding-right: 9.4px;
   padding-left: 9.4px;
@@ -730,7 +730,7 @@ exports[`Storyshots COMPONENTS|Controls/Buttons With left and right icons 1`] = 
   -webkit-transform: translateZ(0);
   -ms-transform: translateZ(0);
   transform: translateZ(0);
-  border-radius: 15px;
+  border-radius: 9px;
   padding: 6.0px;
   padding-right: 9.4px;
   padding-left: 9.4px;

--- a/src/components/Button/__snapshots__/stories.storyshot
+++ b/src/components/Button/__snapshots__/stories.storyshot
@@ -27,7 +27,7 @@ exports[`Storyshots COMPONENTS|Controls/Buttons Button as <a href="" /> 1`] = `
   -webkit-transform: translateZ(0);
   -ms-transform: translateZ(0);
   transform: translateZ(0);
-  border-radius: 9px;
+  border-radius: 6px;
   padding: 6.0px;
   padding-right: 15px;
   padding-left: 15px;
@@ -108,7 +108,7 @@ exports[`Storyshots COMPONENTS|Controls/Buttons Default 1`] = `
   -webkit-transform: translateZ(0);
   -ms-transform: translateZ(0);
   transform: translateZ(0);
-  border-radius: 9px;
+  border-radius: 6px;
   padding: 6.0px;
   padding-right: 15px;
   padding-left: 15px;
@@ -206,7 +206,7 @@ exports[`Storyshots COMPONENTS|Controls/Buttons Icon-only button (custom icon) 1
   -webkit-transform: translateZ(0);
   -ms-transform: translateZ(0);
   transform: translateZ(0);
-  border-radius: 9px;
+  border-radius: 6px;
   padding: 11.0px;
   -webkit-transition: 0.15s ease-out;
   transition: 0.15s ease-out;
@@ -328,7 +328,7 @@ exports[`Storyshots COMPONENTS|Controls/Buttons Icon-only button 1`] = `
   -webkit-transform: translateZ(0);
   -ms-transform: translateZ(0);
   transform: translateZ(0);
-  border-radius: 9px;
+  border-radius: 6px;
   padding: 11.0px;
   -webkit-transition: 0.15s ease-out;
   transition: 0.15s ease-out;
@@ -452,7 +452,7 @@ exports[`Storyshots COMPONENTS|Controls/Buttons Loading button 1`] = `
   -webkit-transform: translateZ(0);
   -ms-transform: translateZ(0);
   transform: translateZ(0);
-  border-radius: 9px;
+  border-radius: 6px;
   padding: 11.0px;
   -webkit-transition: 0.15s ease-out;
   transition: 0.15s ease-out;
@@ -574,7 +574,7 @@ exports[`Storyshots COMPONENTS|Controls/Buttons With custom icons 1`] = `
   -webkit-transform: translateZ(0);
   -ms-transform: translateZ(0);
   transform: translateZ(0);
-  border-radius: 9px;
+  border-radius: 6px;
   padding: 6.0px;
   padding-right: 9.4px;
   padding-left: 9.4px;
@@ -730,7 +730,7 @@ exports[`Storyshots COMPONENTS|Controls/Buttons With left and right icons 1`] = 
   -webkit-transform: translateZ(0);
   -ms-transform: translateZ(0);
   transform: translateZ(0);
-  border-radius: 9px;
+  border-radius: 6px;
   padding: 6.0px;
   padding-right: 9.4px;
   padding-left: 9.4px;

--- a/src/components/Button/styled.js
+++ b/src/components/Button/styled.js
@@ -59,7 +59,7 @@ const calculateBorderRadius = (size, neighboringInGroup) => {
     return `border-radius: ${SIZES[size]}px 0 0 ${SIZES[size]}px;`
   }
 
-  return `border-radius: 9px;`
+  return `border-radius: 6px;`
 }
 const getButtonColor = (props) => {
   const { theme, variant } = props

--- a/src/components/Button/styled.js
+++ b/src/components/Button/styled.js
@@ -50,17 +50,13 @@ const calculateTextPadding = (size, hasLeftIcon, hasRightIcon) => {
   return `0 ${hasRightIcon ? iconPadding : 0}px 0 ${hasLeftIcon ? iconPadding : 0}px`
 }
 
-const calculateBorderRadius = (size, neighboringInGroup, isRoundedRadius) => {
+const calculateBorderRadius = (size, neighboringInGroup) => {
   if (neighboringInGroup === 'both') {
     return ''
   } else if (neighboringInGroup === 'left') {
     return `border-radius: 0 ${SIZES[size]}px ${SIZES[size]}px 0;`
   } else if (neighboringInGroup === 'right') {
     return `border-radius: ${SIZES[size]}px 0 0 ${SIZES[size]}px;`
-  }
-
-  if (isRoundedRadius) {
-    return `border-radius: 100%;`
   }
 
   return `border-radius: 9px;`
@@ -120,8 +116,8 @@ export const StyledButton = styled.button`
   // Fix circle-to-rect render bug in chrome
   transform: translateZ(0);
 
-  ${({ size, neighboringInGroup, isRoundedRadius }) => (
-    calculateBorderRadius(size, neighboringInGroup, isRoundedRadius)
+  ${({ size, neighboringInGroup }) => (
+    calculateBorderRadius(size, neighboringInGroup)
   )};
 
   ${({ size, isIconOnly, hasLeftIcon, hasRightIcon, neighboringInGroup, variant }) => (

--- a/src/components/Button/styled.js
+++ b/src/components/Button/styled.js
@@ -50,7 +50,7 @@ const calculateTextPadding = (size, hasLeftIcon, hasRightIcon) => {
   return `0 ${hasRightIcon ? iconPadding : 0}px 0 ${hasLeftIcon ? iconPadding : 0}px`
 }
 
-const calculateBorderRadius = (size, neighboringInGroup) => {
+const calculateBorderRadius = (size, neighboringInGroup, isRoundedRadius) => {
   if (neighboringInGroup === 'both') {
     return ''
   } else if (neighboringInGroup === 'left') {
@@ -59,7 +59,11 @@ const calculateBorderRadius = (size, neighboringInGroup) => {
     return `border-radius: ${SIZES[size]}px 0 0 ${SIZES[size]}px;`
   }
 
-  return `border-radius: ${SIZES[size]}px;`
+  if (isRoundedRadius) {
+    return `border-radius: 100%;`
+  }
+
+  return `border-radius: 9px;`
 }
 const getButtonColor = (props) => {
   const { theme, variant } = props
@@ -116,8 +120,8 @@ export const StyledButton = styled.button`
   // Fix circle-to-rect render bug in chrome
   transform: translateZ(0);
 
-  ${({ size, neighboringInGroup }) => (
-    calculateBorderRadius(size, neighboringInGroup)
+  ${({ size, neighboringInGroup, isRoundedRadius }) => (
+    calculateBorderRadius(size, neighboringInGroup, isRoundedRadius)
   )};
 
   ${({ size, isIconOnly, hasLeftIcon, hasRightIcon, neighboringInGroup, variant }) => (

--- a/src/components/Dropdown/__snapshots__/stories.storyshot
+++ b/src/components/Dropdown/__snapshots__/stories.storyshot
@@ -27,7 +27,7 @@ exports[`Storyshots COMPONENTS|Complex controls/Dropdown Defalut 1`] = `
   -webkit-transform: translateZ(0);
   -ms-transform: translateZ(0);
   transform: translateZ(0);
-  border-radius: 15px;
+  border-radius: 9px;
   padding: 6.0px;
   padding-right: 15px;
   padding-left: 15px;

--- a/src/components/Dropdown/__snapshots__/stories.storyshot
+++ b/src/components/Dropdown/__snapshots__/stories.storyshot
@@ -27,7 +27,7 @@ exports[`Storyshots COMPONENTS|Complex controls/Dropdown Defalut 1`] = `
   -webkit-transform: translateZ(0);
   -ms-transform: translateZ(0);
   transform: translateZ(0);
-  border-radius: 9px;
+  border-radius: 6px;
   padding: 6.0px;
   padding-right: 15px;
   padding-left: 15px;

--- a/src/components/Modal/__snapshots__/stories.storyshot
+++ b/src/components/Modal/__snapshots__/stories.storyshot
@@ -27,7 +27,7 @@ exports[`Storyshots COMPONENTS|Complex controls/Modal Bottom on mobile 1`] = `
   -webkit-transform: translateZ(0);
   -ms-transform: translateZ(0);
   transform: translateZ(0);
-  border-radius: 15px;
+  border-radius: 9px;
   padding: 6.0px;
   padding-right: 15px;
   padding-left: 15px;
@@ -108,7 +108,7 @@ exports[`Storyshots COMPONENTS|Complex controls/Modal With sizes 1`] = `
   -webkit-transform: translateZ(0);
   -ms-transform: translateZ(0);
   transform: translateZ(0);
-  border-radius: 15px;
+  border-radius: 9px;
   padding: 6.0px;
   padding-right: 15px;
   padding-left: 15px;

--- a/src/components/Modal/__snapshots__/stories.storyshot
+++ b/src/components/Modal/__snapshots__/stories.storyshot
@@ -27,7 +27,7 @@ exports[`Storyshots COMPONENTS|Complex controls/Modal Bottom on mobile 1`] = `
   -webkit-transform: translateZ(0);
   -ms-transform: translateZ(0);
   transform: translateZ(0);
-  border-radius: 9px;
+  border-radius: 6px;
   padding: 6.0px;
   padding-right: 15px;
   padding-left: 15px;
@@ -108,7 +108,7 @@ exports[`Storyshots COMPONENTS|Complex controls/Modal With sizes 1`] = `
   -webkit-transform: translateZ(0);
   -ms-transform: translateZ(0);
   transform: translateZ(0);
-  border-radius: 9px;
+  border-radius: 6px;
   padding: 6.0px;
   padding-right: 15px;
   padding-left: 15px;

--- a/src/components/Modal/styled.js
+++ b/src/components/Modal/styled.js
@@ -1,5 +1,5 @@
 import styled from 'styled-components'
-import { borderRadiusCircle, borderRadiusLarge } from 'utils/borderRadius'
+import { borderRadiusLarge } from 'utils/borderRadius'
 import mq from 'utils/media-queries'
 import H4 from 'components/Typography/H4'
 import Icon from 'components/Icon'
@@ -103,7 +103,6 @@ export const CloseButton = styled.span`
   `}
   ${mq.handheld`
     background: ${({ theme }) => theme.color.miscLightest};
-    ${borderRadiusCircle.all}
     margin-left: 32px;
     position: absolute;
     right: 18px;

--- a/src/components/Modal/styled.js
+++ b/src/components/Modal/styled.js
@@ -1,5 +1,5 @@
 import styled from 'styled-components'
-import { borderRadiusLarge } from 'utils/borderRadius'
+import { borderRadiusCircle, borderRadiusLarge } from 'utils/borderRadius'
 import mq from 'utils/media-queries'
 import H4 from 'components/Typography/H4'
 import Icon from 'components/Icon'
@@ -103,6 +103,7 @@ export const CloseButton = styled.span`
   `}
   ${mq.handheld`
     background: ${({ theme }) => theme.color.miscLightest};
+    ${borderRadiusCircle.all}
     margin-left: 32px;
     position: absolute;
     right: 18px;

--- a/src/components/PassengerPicker/__snapshots__/stories.storyshot
+++ b/src/components/PassengerPicker/__snapshots__/stories.storyshot
@@ -46,7 +46,7 @@ exports[`Storyshots COMPONENTS|Complex controls/PassengerPicker Defalut 1`] = `
   -webkit-transform: translateZ(0);
   -ms-transform: translateZ(0);
   transform: translateZ(0);
-  border-radius: 9px;
+  border-radius: 6px;
   padding: 6.0px;
   -webkit-transition: 0.15s ease-out;
   transition: 0.15s ease-out;
@@ -73,7 +73,7 @@ exports[`Storyshots COMPONENTS|Complex controls/PassengerPicker Defalut 1`] = `
   -webkit-transform: translateZ(0);
   -ms-transform: translateZ(0);
   transform: translateZ(0);
-  border-radius: 9px;
+  border-radius: 6px;
   padding: 6.0px;
   -webkit-transition: 0.15s ease-out;
   transition: 0.15s ease-out;

--- a/src/components/PassengerPicker/__snapshots__/stories.storyshot
+++ b/src/components/PassengerPicker/__snapshots__/stories.storyshot
@@ -46,7 +46,7 @@ exports[`Storyshots COMPONENTS|Complex controls/PassengerPicker Defalut 1`] = `
   -webkit-transform: translateZ(0);
   -ms-transform: translateZ(0);
   transform: translateZ(0);
-  border-radius: 15px;
+  border-radius: 9px;
   padding: 6.0px;
   -webkit-transition: 0.15s ease-out;
   transition: 0.15s ease-out;
@@ -73,7 +73,7 @@ exports[`Storyshots COMPONENTS|Complex controls/PassengerPicker Defalut 1`] = `
   -webkit-transform: translateZ(0);
   -ms-transform: translateZ(0);
   transform: translateZ(0);
-  border-radius: 15px;
+  border-radius: 9px;
   padding: 6.0px;
   -webkit-transition: 0.15s ease-out;
   transition: 0.15s ease-out;

--- a/src/components/Popover/__snapshots__/stories.storyshot
+++ b/src/components/Popover/__snapshots__/stories.storyshot
@@ -46,7 +46,7 @@ exports[`Storyshots COMPONENTS|Controls/Popover With \`align\` prop 1`] = `
   -webkit-transform: translateZ(0);
   -ms-transform: translateZ(0);
   transform: translateZ(0);
-  border-radius: 9px;
+  border-radius: 6px;
   padding: 6.0px;
   -webkit-transition: 0.15s ease-out;
   transition: 0.15s ease-out;
@@ -224,7 +224,7 @@ exports[`Storyshots COMPONENTS|Controls/Popover With Header&Large 1`] = `
   -webkit-transform: translateZ(0);
   -ms-transform: translateZ(0);
   transform: translateZ(0);
-  border-radius: 9px;
+  border-radius: 6px;
   padding: 6.0px;
   -webkit-transition: 0.15s ease-out;
   transition: 0.15s ease-out;
@@ -347,7 +347,7 @@ exports[`Storyshots COMPONENTS|Controls/Popover default 1`] = `
   -webkit-transform: translateZ(0);
   -ms-transform: translateZ(0);
   transform: translateZ(0);
-  border-radius: 9px;
+  border-radius: 6px;
   padding: 6.0px;
   -webkit-transition: 0.15s ease-out;
   transition: 0.15s ease-out;

--- a/src/components/Popover/__snapshots__/stories.storyshot
+++ b/src/components/Popover/__snapshots__/stories.storyshot
@@ -46,7 +46,7 @@ exports[`Storyshots COMPONENTS|Controls/Popover With \`align\` prop 1`] = `
   -webkit-transform: translateZ(0);
   -ms-transform: translateZ(0);
   transform: translateZ(0);
-  border-radius: 15px;
+  border-radius: 9px;
   padding: 6.0px;
   -webkit-transition: 0.15s ease-out;
   transition: 0.15s ease-out;
@@ -224,7 +224,7 @@ exports[`Storyshots COMPONENTS|Controls/Popover With Header&Large 1`] = `
   -webkit-transform: translateZ(0);
   -ms-transform: translateZ(0);
   transform: translateZ(0);
-  border-radius: 15px;
+  border-radius: 9px;
   padding: 6.0px;
   -webkit-transition: 0.15s ease-out;
   transition: 0.15s ease-out;
@@ -347,7 +347,7 @@ exports[`Storyshots COMPONENTS|Controls/Popover default 1`] = `
   -webkit-transform: translateZ(0);
   -ms-transform: translateZ(0);
   transform: translateZ(0);
-  border-radius: 15px;
+  border-radius: 9px;
   padding: 6.0px;
   -webkit-transition: 0.15s ease-out;
   transition: 0.15s ease-out;

--- a/src/components/Tooltip/__snapshots__/stories.storyshot
+++ b/src/components/Tooltip/__snapshots__/stories.storyshot
@@ -46,7 +46,7 @@ exports[`Storyshots COMPONENTS|Controls/Tooltip default 1`] = `
   -webkit-transform: translateZ(0);
   -ms-transform: translateZ(0);
   transform: translateZ(0);
-  border-radius: 9px;
+  border-radius: 6px;
   padding: 6.0px;
   -webkit-transition: 0.15s ease-out;
   transition: 0.15s ease-out;

--- a/src/components/Tooltip/__snapshots__/stories.storyshot
+++ b/src/components/Tooltip/__snapshots__/stories.storyshot
@@ -46,7 +46,7 @@ exports[`Storyshots COMPONENTS|Controls/Tooltip default 1`] = `
   -webkit-transform: translateZ(0);
   -ms-transform: translateZ(0);
   transform: translateZ(0);
-  border-radius: 15px;
+  border-radius: 9px;
   padding: 6.0px;
   -webkit-transition: 0.15s ease-out;
   transition: 0.15s ease-out;


### PR DESCRIPTION
Для https://kupibiletru.atlassian.net/browse/SITE-1157
Обновленный бордер радиус для всех кнопок (включая круглые) - 9px (кроме кнопки с инпутом, см. скрин). Все запрувлено у Игоря.
<img width="188" alt="2018-11-08 17 08 15" src="https://user-images.githubusercontent.com/646755/48203594-f7eec080-e378-11e8-804d-6bc386e15401.png">
<img width="360" alt="2018-11-08 16 57 34" src="https://user-images.githubusercontent.com/646755/48203595-f8875700-e378-11e8-896c-732684aa3102.png">

