### PR TITLE
Add optional custom icon to ButtonWithBorder

### DIFF
--- a/src/components/ButtonWithBorder/index.js
+++ b/src/components/ButtonWithBorder/index.js
@@ -1,10 +1,10 @@
 // @flow
 
-import React from 'react'
+import React, { Component } from 'react'
 import type { Node } from 'react'
 import Icon from 'components/Icon'
 
-import { StyledButtonWithBorder, ButtonText } from './styled'
+import { StyledButtonWithBorder, ButtonText, IconWrap } from './styled'
 
 type Props = {
   children: Node,
@@ -14,42 +14,66 @@ type Props = {
   themeColor?: string,
   overshadowThemeColor?: string,
   className?: string,
+  customIcon?: Node,
 }
 
-const defaultProps = {
-  onClick: () => null,
-  iconName: 'cross',
-  themeColor: 'secondaryDarkest',
-  withOvershadow: false,
-  overshadowThemeColor: 'miscLightest',
-  className: null,
+class ButtonWithBorder extends Component<Props> {
+  static defaultProps = {
+    onClick: () => null,
+    iconName: null,
+    themeColor: 'secondaryDarkest',
+    withOvershadow: false,
+    overshadowThemeColor: 'miscLightest',
+    className: null,
+    customIcon: null,
+  }
+
+  getIcon() {
+    const { iconName, customIcon, themeColor } = this.props
+
+    if (customIcon && React.isValidElement(customIcon)) {
+      return (
+        <IconWrap>
+          {customIcon}
+        </IconWrap>
+      )
+    }
+
+    if (iconName) {
+      return (
+        <Icon size="normal" name={iconName} fill={themeColor} />
+      )
+    }
+
+    return null
+  }
+
+  render() {
+    const {
+      children,
+      withOvershadow,
+      themeColor,
+      onClick,
+      overshadowThemeColor,
+      className,
+    } = this.props
+
+    return (
+      <StyledButtonWithBorder
+        onClick={onClick}
+        themeColor={themeColor}
+        withOvershadow={withOvershadow}
+        overshadowThemeColor={overshadowThemeColor}
+        className={className}
+      >
+        <ButtonText>
+          {children}
+        </ButtonText>
+        {this.getIcon()}
+      </StyledButtonWithBorder>
+    )
+  }
 }
 
-const ButtonWithBorder = ({
-  children,
-  withOvershadow,
-  themeColor,
-  onClick,
-  iconName,
-  overshadowThemeColor,
-  className,
-}: Props) => {
-  return (
-    <StyledButtonWithBorder
-      onClick={onClick}
-      themeColor={themeColor}
-      withOvershadow={withOvershadow}
-      overshadowThemeColor={overshadowThemeColor}
-      className={className}
-    >
-      <ButtonText>
-        {children}
-      </ButtonText>
-      <Icon size="normal" name={iconName} fill={themeColor} />
-    </StyledButtonWithBorder>
-  )
-}
-
-ButtonWithBorder.defaultProps = defaultProps
 
 export default ButtonWithBorder

--- a/src/components/ButtonWithBorder/stories.js
+++ b/src/components/ButtonWithBorder/stories.js
@@ -7,15 +7,6 @@ import { color } from 'components/ThemeProvider/theme'
 import ButtonWithBorder from 'components/ButtonWithBorder'
 import Icon from 'components/Icon'
 
-const withOvershadowSelect = (defaultValue = false) => select(
-  'withOvershadow',
-  {
-    true: true,
-    false: false,
-  },
-  defaultValue,
-)
-
 const iconNameSelect = (defaultValue = 'cross') => select(
   'iconName',
   icons,
@@ -31,6 +22,15 @@ const iconColorSelect = (defaultValue = 'secondaryDarkest') => select(
 const themeColorSelect = (defaultValue = 'secondaryDarkest') => select(
   'themeColor',
   Object.keys(color),
+  defaultValue,
+)
+
+const withOvershadowSelect = (defaultValue = false) => select(
+  'withOvershadow',
+  {
+    true: true,
+    false: false,
+  },
   defaultValue,
 )
 

--- a/src/components/ButtonWithBorder/stories.js
+++ b/src/components/ButtonWithBorder/stories.js
@@ -5,6 +5,7 @@ import icons from '@kupibilet/icons/dist/sprite.json'
 
 import { color } from 'components/ThemeProvider/theme'
 import ButtonWithBorder from 'components/ButtonWithBorder'
+import Icon from 'components/Icon'
 
 const withOvershadowSelect = (defaultValue = false) => select(
   'withOvershadow',
@@ -18,6 +19,12 @@ const withOvershadowSelect = (defaultValue = false) => select(
 const iconNameSelect = (defaultValue = 'cross') => select(
   'iconName',
   icons,
+  defaultValue,
+)
+
+const iconColorSelect = (defaultValue = 'secondaryDarkest') => select(
+  'iconColor',
+  Object.keys(color),
   defaultValue,
 )
 
@@ -38,6 +45,16 @@ storiesOf('COMPONENTS|Controls/ButtonWithBorder', module)
     <ButtonWithBorder
       themeColor={themeColorSelect()}
       iconName={iconNameSelect()}
+      withOvershadow={withOvershadowSelect()}
+      overshadowThemeColor={overshadowThemeColorSelect()}
+    >
+      {text('text', 'Сбросить все фильтры')}
+    </ButtonWithBorder>
+  ))
+  .add('With custom icon', () => (
+    <ButtonWithBorder
+      themeColor={themeColorSelect('primaryDarkest')}
+      rightIcon={<Icon size="normal" name={iconNameSelect()} fill={iconColorSelect('primaryDarkest')} />}
       withOvershadow={withOvershadowSelect()}
       overshadowThemeColor={overshadowThemeColorSelect()}
     >

--- a/src/components/ButtonWithBorder/styled.js
+++ b/src/components/ButtonWithBorder/styled.js
@@ -56,3 +56,10 @@ export const ButtonText = styled.span`
   margin-right: 8px;
   padding-bottom: 2px;
 `
+
+export const IconWrap = styled.span`
+  display: inline-flex;
+  vertical-align: top;
+  justify-content: center;
+  align-items: center;
+`


### PR DESCRIPTION
• Make iconName optional for ButtonWithBorder — can use button without icon.
• Add optional custom icon Node for ButtonWithBorder.